### PR TITLE
Could not save participant survey. XML hidden fields not rendering.

### DIFF
--- a/webpages/xsl/RenderSurvey.xsl
+++ b/webpages/xsl/RenderSurvey.xsl
@@ -21,7 +21,7 @@
       <xsl:value-of select="$UpdateMessage" disable-output-escaping="yes"/>
     </div>
     <form name="partsurveyform" method="POST">
-      <xsl:if test="buttons != '' and buttons != 'close'">
+      <xsl:if test="$buttons != '' and $buttons != 'close'">
         <xsl:attribute name="action">
           <xsl:text>PartSurvey.php</xsl:text>
         </xsl:attribute>


### PR DESCRIPTION
XML template was referencing "buttons" instead of "$buttons", which was causing hidden fields to not render.
Corrected field reference to use $, and form submits correctly.